### PR TITLE
docs(skills): add svas agent skill

### DIFF
--- a/skills/svas/SKILL.md
+++ b/skills/svas/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: svas
+description: >
+  Async-first Svelte stores (svas): fetching, caching, revalidation, persistence via `Maybe<T> = null | T | Error`. Use when code imports from `svas` or for async data in Svelte — loading/error UI, `value`/`values`/`collection`, `<Async>`, caching a fetch, or keeping data in sync.
+---
+
+# svas — Svelte Async Stores
+
+Stores that fetch lazily, cache, revalidate, and persist. Every store emits one type:
+
+```ts
+type Maybe<T, E extends Error = Error> = null | T | E
+//   null  → no data yet (loading / cleared / not fetched)
+//   T     → resolved value
+//   E     → fetch error (errors are values, never thrown)
+```
+
+```ts
+import {
+  value, values, collection,           // stores
+  ok, ensure, having, awaited, once,   // guards & awaiting
+  combined, sync, Async,               // compose & render
+  type Maybe
+} from 'svas'
+```
+
+## Shared lifecycle
+
+Every store fetches on **first subscribe**, then auto-revalidates. Common options:
+
+| Option | Meaning |
+|--------|---------|
+| `get` | fetcher returning `Promise<T \| Error>` |
+| `revalidate` | ms before re-fetch (default `300_000`; `Infinity` disables) |
+| `persist` | mirror into storage under this key |
+| `session` | use `sessionStorage` instead of `localStorage` |
+| `stale` | keep previous value visible while revalidating (default `false`) |
+| `bind` | `Readable<unknown \| null>` — reset/clear store when bound store is `null` (tie data to a session/user) |
+| `default` | initial value when nothing is persisted |
+
+## Stores
+
+### `value<T>` — one async value
+
+`Writable<T | null>`. For single fetched values, auth tokens, transient UI flags.
+
+```ts
+const me = value<User>({ get: () => api.me(), persist: 'user', bind: session })
+const seen = value<number>({ persist: 'seen', default: 0 }) // transient/local-only
+```
+
+Methods: `subscribe` · `set(v)` · `update(fn)` · `extract(): T | null` (sync read) · `sync()` (revalidate if stale).
+
+### `values<T>` — keyed cache
+
+A map of independent `Readable<Maybe<T>>` lifecycles, one per key.
+
+```ts
+const products = values<Product>({ get: (id) => api.product(id), stale: true, persist: 'products' })
+
+const one = products.get('42')      // Readable<Maybe<Product>>, fetches if missing
+products.set('42', next)            // write by key
+products.extract('42')              // Product | null, sync
+```
+
+Methods: `get(key, { fetch? })` · `set(key, v, { stash? })` · `reset(key)` (restore stashed value) · `extract(key)` · `delete(key)` · `clear()`.
+
+Extra options: `permanent` (don't revalidate persisted entries on startup). `stash: true` on `set` remembers the prior persisted value so `reset(key)` can roll back — use for optimistic updates.
+
+### `collection<T>` — list of `Identifiable` items
+
+`Readable<Maybe<T[]>>`. Items must have `{ id: string }`. Pass a `values` store to also observe items individually via `get(id)`.
+
+```ts
+const items = values<Todo>()                      // side store, no options
+const todos = collection<Todo>({
+  get: () => api.todos(),
+  values: items,                                  // enables todos.get(id) / extract(id)
+  stale: true, persist: 'todos', bind: session
+})
+```
+
+Methods: `subscribe` · `add(item)` · `set(item, { add? })` (replace by id; `add` inserts if absent) · `update(id, fn, opts?)` · `delete(id)` · `replace(items)` · `get(id)`/`extract(id)` (require `values`) · `sync(): this` · `fetch(): Promise<this>`.
+
+Mutations mirror into the `values` store, so components subscribed via `get(id)` update without re-fetching.
+
+## Guards & extraction
+
+Never use `?.` on a `Maybe<T>` — an `Error` has no domain properties. Narrow first.
+
+```ts
+ok($store)          // boolean type guard: narrows Maybe<T> → T (excludes null | Error)
+ensure(store)       // sync read, THROWS if null/Error — use when value must exist now (e.g. auth)
+store.extract(key?) // sync read, T | null (ignores errors) — never throws
+```
+
+```ts
+if (ok($todos)) $todos.length        // typed as T
+items.filter((i) => ok(i.account) && !i.account.deleted)   // ✅ guard before access
+```
+
+## Awaiting
+
+```ts
+await having(store)   // first non-null value; REJECTS on Error — services needing auth
+await awaited(store)  // first non-null value; returns Error as a value (never rejects)
+await once(store, (v) => v === 'ready')   // first value satisfying a condition
+```
+
+## Compose & render
+
+### `combined(...stores)`
+
+One `Maybe` from many: tuple when **all** resolve, first `Error`, else `null`. Spreadable.
+
+```ts
+const both = combined(user, settings)        // Maybe<[User, Settings]>
+combined(list, account, ...extras)           // spread supported
+```
+
+### `sync(store, item, { delete? })`
+
+Merge a versioned item into a `collection` or `value`, respecting `_version`; removes on `_deleted` (unless `delete: false`). For applying server/realtime events.
+
+```ts
+interface Comparable { id: string; _version: number; _deleted?: number | null }
+sync(todos, incoming)                  // insert/update if newer, delete if tombstoned
+```
+
+### `<Async>` — render a `Maybe`
+
+```svelte
+<Async store={todos}>
+  {#snippet awaited(todos)}{#each todos as t}<Row {t} />{/each}{/snippet}
+  {#snippet waiting()}<Spinner />{/snippet}   <!-- optional; default loader otherwise -->
+  {#snippet error(e)}<Err {e} />{/snippet}    <!-- optional; default error UI otherwise -->
+</Async>
+```
+
+Props: `store` (required), `awaited` snippet (required), optional `waiting` / `error` snippets, `silent` (suppress default loader/error chrome). Combine with `combined` to await several at once.
+
+## Rules
+
+- **Errors are values** — fetchers and services return `T | Error`; check `instanceof Error`, never `try/catch` for expected failures.
+- **Guard before access** — `ok()`/`ensure()`/`extract()`, never `?.` on `Maybe<T>`.
+- **One store per source** — derive everything else; don't duplicate fetched data into local state.
+- **Lazy by design** — a store does nothing until subscribed; `$store`, `<Async>`, `get`, `having`, or `.subscribe` triggers it.
+
+## Advanced
+
+For derived `Maybe` stores with live subscriptions/cleanup, realtime event wiring, linked/enriched entities, and optimistic update patterns, see [references/patterns.md](references/patterns.md).

--- a/skills/svas/SKILL.md
+++ b/skills/svas/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: svas
 description: >
-  Async-first Svelte stores (svas): fetching, caching, revalidation, persistence via `Maybe<T> = null | T | Error`. Use when code imports from `svas` or for async data in Svelte — loading/error UI, `value`/`values`/`collection`, `<Async>`, caching a fetch, or keeping data in sync.
+  Async Svelte stores (svas): fetching, caching, revalidation, persistence.
+  Use when UI presents data from the API.
 ---
 
 # svas — Svelte Async Stores
 
-Stores that fetch lazily, cache, revalidate, and persist. Every store emits one type:
+Stores that fetch lazily, cache, revalidate, and persist. Every store emits one of three types:
 
 ```ts
 type Maybe<T, E extends Error = Error> = null | T | E
@@ -32,24 +33,29 @@ Every store fetches on **first subscribe**, then auto-revalidates. Common option
 |--------|---------|
 | `get` | fetcher returning `Promise<T \| Error>` |
 | `revalidate` | ms before re-fetch (default `300_000`; `Infinity` disables) |
-| `persist` | mirror into storage under this key |
+| `persist` | mirror into local storage under this key |
 | `session` | use `sessionStorage` instead of `localStorage` |
 | `stale` | keep previous value visible while revalidating (default `false`) |
-| `bind` | `Readable<unknown \| null>` — reset/clear store when bound store is `null` (tie data to a session/user) |
+| `bind` | `Readable<unknown \| null>` — reset/clear store when bound store is `null` (tie data to a user) |
 | `default` | initial value when nothing is persisted |
 
 ## Stores
+
+All stores implements Readable interface from svelte/store.
+
+Use `persist` whenever it makes sense to persist the data, it will vastly speed up the initial load.
+If store contains user-bound data, use `bind` to reset the store when the user is logged out.
 
 ### `value<T>` — one async value
 
 `Writable<T | null>`. For single fetched values, auth tokens, transient UI flags.
 
 ```ts
-const me = value<User>({ get: () => api.me(), persist: 'user', bind: session })
+const me = value<User>({ get: () => api.me(), persist: 'user' })
 const seen = value<number>({ persist: 'seen', default: 0 }) // transient/local-only
 ```
 
-Methods: `subscribe` · `set(v)` · `update(fn)` · `extract(): T | null` (sync read) · `sync()` (revalidate if stale).
+Methods: `set(v)`, `update(fn)`, `extract(): T | null` (sync read), `sync()` (revalidate if stale).
 
 ### `values<T>` — keyed cache
 
@@ -72,11 +78,12 @@ Extra options: `permanent` (don't revalidate persisted entries on startup). `sta
 `Readable<Maybe<T[]>>`. Items must have `{ id: string }`. Pass a `values` store to also observe items individually via `get(id)`.
 
 ```ts
-const items = values<Todo>()                      // side store, no options
 const todos = collection<Todo>({
   get: () => api.todos(),
-  values: items,                                  // enables todos.get(id) / extract(id)
-  stale: true, persist: 'todos', bind: session
+  values: values<Todo>(), // enables todos.get(id) / extract(id)
+  stale: true, 
+  persist: 'todos', 
+  bind: session
 })
 ```
 
@@ -90,7 +97,7 @@ Never use `?.` on a `Maybe<T>` — an `Error` has no domain properties. Narrow f
 
 ```ts
 ok($store)          // boolean type guard: narrows Maybe<T> → T (excludes null | Error)
-ensure(store)       // sync read, THROWS if null/Error — use when value must exist now (e.g. auth)
+ensure(store)       // sync read, THROWS if null/Error — use when value must exist now (e.g. unsafe net requests in response to user action)
 store.extract(key?) // sync read, T | null (ignores errors) — never throws
 ```
 
@@ -109,35 +116,46 @@ await once(store, (v) => v === 'ready')   // first value satisfying a condition
 
 ## Compose & render
 
-### `combined(...stores)`
-
-One `Maybe` from many: tuple when **all** resolve, first `Error`, else `null`. Spreadable.
-
-```ts
-const both = combined(user, settings)        // Maybe<[User, Settings]>
-combined(list, account, ...extras)           // spread supported
-```
-
-### `sync(store, item, { delete? })`
-
-Merge a versioned item into a `collection` or `value`, respecting `_version`; removes on `_deleted` (unless `delete: false`). For applying server/realtime events.
-
-```ts
-interface Comparable { id: string; _version: number; _deleted?: number | null }
-sync(todos, incoming)                  // insert/update if newer, delete if tombstoned
-```
-
 ### `<Async>` — render a `Maybe`
 
 ```svelte
 <Async store={todos}>
-  {#snippet awaited(todos)}{#each todos as t}<Row {t} />{/each}{/snippet}
+  {#snippet awaited(todos)}
+    <!-- here todos are T[] -->
+    {#each todos as t}<Row {t} />{/each}
+  {/snippet}
   {#snippet waiting()}<Spinner />{/snippet}   <!-- optional; default loader otherwise -->
   {#snippet error(e)}<Err {e} />{/snippet}    <!-- optional; default error UI otherwise -->
 </Async>
 ```
 
 Props: `store` (required), `awaited` snippet (required), optional `waiting` / `error` snippets, `silent` (suppress default loader/error chrome). Combine with `combined` to await several at once.
+
+### `combined(...stores)`
+
+One `Maybe` from many: tuple when **all** resolve, first `Error`, else `null`. Spreadable.
+
+```svelte
+<Async store={combined(account, todos)}>
+  {#snippet awaited([account, todos])}
+    <!-- here account is U and todos is T[] -->
+    <Profile {account} />
+    {#each todos as t}<Row {t} />{/each}
+  {/snippet}
+</Async>
+```
+
+### `sync(store, item, { delete? })`
+
+Conflict-free update.
+
+T must implement interface Comparable { id: string; _version: number;_deleted?: number | null }
+
+Merge a versioned item into a `collection` or `value`, respecting `_version`; removes on `_deleted` (unless `delete: false`). For applying server/realtime events.
+
+```ts
+events.on('todos.sync', (todo) => sync(todos, todo))
+```
 
 ## Rules
 

--- a/skills/svas/references/patterns.md
+++ b/skills/svas/references/patterns.md
@@ -1,0 +1,89 @@
+# svas — advanced patterns
+
+Idioms for non-trivial usage. All build on `Maybe<T> = null | T | Error` and the `ok()` guard.
+
+## Derived `Maybe` stores
+
+Compute one async store from others with `svelte/store`'s `derived`. Forward `null`/`Error` early, and return a cleanup function when you subscribe to linked entities.
+
+```ts
+export const enriched = derived<[typeof list, typeof me], Maybe<Item[]>>(
+  [list, me],
+  ([$list, $me], set, update) => {
+    if (!ok($list)) return set($list)   // forward loading/error verbatim
+    if (!ok($me)) return set($me)
+
+    const items = $list.map((i) => map(i, $me.id))
+    set(items)
+
+    // live updates: re-emit when a linked entity changes
+    const unsubs = items.map((item) =>
+      accounts.get(item.owner).subscribe((account) =>
+        update((items) => {
+          if (!ok(items) || !ok(account)) return items
+          const i = items.findIndex((v) => v.owner === account.id)
+          if (i < 0) return items
+          items[i] = { ...items[i], account }
+          return items
+        })
+      )
+    )
+
+    return () => unsubs.forEach((u) => u())   // cleanup on unsubscribe
+  }
+)
+```
+
+Key moves: `if (!ok(x)) return set(x)` to forward non-resolved states, `update()` for incremental edits, return a teardown for any subscriptions you open.
+
+## Realtime event wiring
+
+Apply server events into stores with `sync` (collections/values-backed) or `.set` (standalone `values`). Mutating functions sync their own result so the optimistic and authoritative paths converge.
+
+```ts
+// collection backed by a values side store
+events.on('todos.sync', (todo) => sync(todos, todo))
+
+// standalone values map
+events.on('accounts.sync', (a) => accounts.set(a.id, a))
+
+export async function add(input: Input): Promise<Todo | Error> {
+  const me = await having(account)        // wait for auth
+  const res = await net.add(me.id, input)
+  if (res instanceof Error) return res     // error as value
+  sync(todos, res)                         // merge authoritative result
+  return res
+}
+```
+
+## Linked / enriched entities
+
+Join a network type with domain data. Use `.extract()` for a sync snapshot at map time; subscribe via `.get()` inside derived stores for live enrichment.
+
+```ts
+export interface Contact extends net.Contact {
+  account: Maybe<Account>
+}
+
+export function map(entry: net.Contact): Contact {
+  return { ...entry, account: accounts.extract(entry.owner) }  // sync snapshot
+}
+```
+
+Hold a `Maybe<T>` per link; never reach through it with `?.` — guard with `ok()` before use. For many links, `Record<string, Maybe<T>>` keyed by id.
+
+## Optimistic updates with rollback
+
+`values.set(key, v, { stash: true })` remembers the prior persisted value; `reset(key)` restores it if the request fails.
+
+```ts
+products.set(id, optimistic, { stash: true })
+const res = await net.save(optimistic)
+if (res instanceof Error) products.reset(id)   // roll back
+else products.set(id, res)
+```
+
+## `ensure` vs `having`
+
+- `ensure(store)` — **sync**, throws if `null`/`Error`. Use when the value must already exist (auth checks inside service functions).
+- `having(store)` — **async**, waits for a resolved value, rejects on `Error`. Use at init time when the value may still be loading.

--- a/skills/svas/references/patterns.md
+++ b/skills/svas/references/patterns.md
@@ -7,7 +7,9 @@ Idioms for non-trivial usage. All build on `Maybe<T> = null | T | Error` and the
 Compute one async store from others with `svelte/store`'s `derived`. Forward `null`/`Error` early, and return a cleanup function when you subscribe to linked entities.
 
 ```ts
-export const enriched = derived<[typeof list, typeof me], Maybe<Item[]>>(
+const internal = collection<Item>({ get: () => api.get(), persist: 'items' })
+
+export const items = derived<[typeof internal, typeof me], Maybe<Item[]>>(
   [list, me],
   ([$list, $me], set, update) => {
     if (!ok($list)) return set($list)   // forward loading/error verbatim
@@ -37,6 +39,8 @@ export const enriched = derived<[typeof list, typeof me], Maybe<Item[]>>(
 Key moves: `if (!ok(x)) return set(x)` to forward non-resolved states, `update()` for incremental edits, return a teardown for any subscriptions you open.
 
 ## Realtime event wiring
+
+> Usually used with antcn/@realtime
 
 Apply server events into stores with `sync` (collections/values-backed) or `.set` (standalone `values`). Mutating functions sync their own result so the optimistic and authoritative paths converge.
 
@@ -77,13 +81,15 @@ Hold a `Maybe<T>` per link; never reach through it with `?.` — guard with `ok(
 `values.set(key, v, { stash: true })` remembers the prior persisted value; `reset(key)` restores it if the request fails.
 
 ```ts
-products.set(id, optimistic, { stash: true })
-const res = await net.save(optimistic)
-if (res instanceof Error) products.reset(id)   // roll back
-else products.set(id, res)
+products.update(id, (product) => ({ ...product, ...properties }))
+
+const res = await net.patch(id, properties)
+
+if (res instanceof Error) return res
+else sync(products, res)
 ```
 
 ## `ensure` vs `having`
 
-- `ensure(store)` — **sync**, throws if `null`/`Error`. Use when the value must already exist (auth checks inside service functions).
-- `having(store)` — **async**, waits for a resolved value, rejects on `Error`. Use at init time when the value may still be loading.
+- `ensure(store)` — **sync**, throws if `null`/`Error`. Use when the value must already exist (auth checks inside service functions called in response to user action).
+- `await having(store)` — **async**, waits for a resolved value, rejects on `Error`. Use at init time when the value may still be loading (initial data fetching when app is starting).


### PR DESCRIPTION
Installable via `npx skills` (skills/svas/SKILL.md). Teaches agents
the svas API — Maybe<T>, value/values/collection, guards, <Async> —
plus advanced patterns (derived stores, realtime sync, optimistic
updates) in references/patterns.md.